### PR TITLE
Updates errorCatcher to also catch async functions

### DIFF
--- a/utils/errorCatcher.ts
+++ b/utils/errorCatcher.ts
@@ -1,10 +1,12 @@
 export default function errorCatcher(originalFunction) {
   // Prevents the server from crashing when the function throws an error
-  return (...args) => {
+  // Returns an async function that wraps originalFunction in a try...catch block.
+  // This handles errors from both synchronous and asynchronous functions.
+  return async (...args) => {
     try {
-      originalFunction(...args);
+      await originalFunction(...args);
     } catch (err) {
-      console.log(err);
+      console.log('Error caught by errorCatcher: ', err);
     }
   };
 }


### PR DESCRIPTION
The issue was that soloModeStudentSendsMessage() is an async function and our errorCatcher function wasn't built for async functions. I updated the errorCatcher to also catch errors thrown in async functions.

Closes https://github.com/mssiegel/Frempco-web-client/issues/86