### PR TITLE
Use the current Gemini model version

### DIFF
--- a/services/gemini.ts
+++ b/services/gemini.ts
@@ -8,7 +8,7 @@ export async function getChatbotReplyMessages(
   chatHistory: string,
 ): Promise<SoloChatMessage[]> {
   const response = await ai.models.generateContent({
-    model: 'gemini-2.5-flash-preview-04-17',
+    model: 'gemini-2.5-flash',
     contents: chatHistory,
     config: {
       systemInstruction: SYSTEM_INSTRUCTION,


### PR DESCRIPTION
The solo chat was breaking as the former Gemini model version we were using is no longer available. This change updates the code to use the latest version of the Gemini model.