### PR TITLE
removes callback when student sends messages

### DIFF
--- a/services/socketIOSetup.ts
+++ b/services/socketIOSetup.ts
@@ -78,7 +78,7 @@ export default function socketIOSetup(server) {
     // New chat message sent from one student to their peer
     socket.on(
       'student sent message',
-      errorCatcher(({ message }, callback) => {
+      errorCatcher(({ message }) => {
         // A student is no longer in the server's classroom when a student's
         // phone goes dark and the socket disconnects and afterwards the student
         // reopens the web app and sends a message.
@@ -86,7 +86,6 @@ export default function socketIOSetup(server) {
           socket.id,
         );
         if (isStudentInsideClassroom) studentSendsMessage(message, socket);
-        else callback({ studentNotInPairedChat: true });
       }),
     );
 
@@ -133,7 +132,7 @@ export default function socketIOSetup(server) {
           // discarded, and chatbotReplyMessages will be empty for this turn.
           if (chatbotReplyMessages.length > 0)
             callback({ chatbotReplyMessages });
-        } else callback({ studentNotInSoloChat: true });
+        }
       }),
     );
 


### PR DESCRIPTION
The backend PR to https://github.com/mssiegel/Frempco-web-client/pull/121

The callback is not needed as the frontend now periodically checks if the student is in the classroom. It no longer checks for a connection when a message is sent.